### PR TITLE
feat: app shell, theme tokens, router, bottom nav + FAB

### DIFF
--- a/paisasplit/lib/app/app.dart
+++ b/paisasplit/lib/app/app.dart
@@ -1,28 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class PaisaSplitApp extends StatelessWidget {
+import 'app_router.dart';
+import 'theme/theme.dart';
+
+class PaisaSplitApp extends ConsumerWidget {
   const PaisaSplitApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
+  Widget build(BuildContext context, WidgetRef ref) {
+    final router = ref.watch(appRouterProvider);
+
+    return MaterialApp.router(
       title: 'PaisaSplit',
-      theme: ThemeData.dark(useMaterial3: true),
       debugShowCheckedModeBanner: false,
-      home: const _PlaceholderHome(),
-    );
-  }
-}
-
-class _PlaceholderHome extends StatelessWidget {
-  const _PlaceholderHome();
-
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: Text('PaisaSplit'),
-      ),
+      theme: buildPaisaTheme(),
+      routerConfig: router,
     );
   }
 }

--- a/paisasplit/lib/app/app_router.dart
+++ b/paisasplit/lib/app/app_router.dart
@@ -1,0 +1,222 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../features/accounts/accounts_screen.dart';
+import '../features/analytics/analytics_screen.dart';
+import '../features/dashboard/activity_detail_screen.dart';
+import '../features/dashboard/dashboard_screen.dart';
+import '../features/expenses/new_expense_screen.dart';
+import '../features/groups/add_member_screen.dart';
+import '../features/groups/group_detail_screen.dart';
+import '../features/groups/group_settings_screen.dart';
+import '../features/groups/groups_screen.dart';
+import '../features/settle/settle_up_screen.dart';
+import '../features/settings/settings_screen.dart';
+import 'theme/colors.dart';
+
+enum AppRoute {
+  dashboard('/dashboard'),
+  groups('/groups'),
+  groupDetail('/groups/:groupId'),
+  analytics('/analytics'),
+  accounts('/accounts'),
+  settings('/settings'),
+  addMember('/groups/:groupId/add-member'),
+  newExpense('/expenses/new'),
+  settleUp('/settle-up'),
+  activityDetail('/activity/:activityId'),
+  groupSettings('/groups/:groupId/settings');
+
+  const AppRoute(this.path);
+  final String path;
+}
+
+final _rootNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'root');
+final _dashboardNavigatorKey =
+    GlobalKey<NavigatorState>(debugLabel: 'dashboardBranch');
+final _groupsNavigatorKey =
+    GlobalKey<NavigatorState>(debugLabel: 'groupsBranch');
+final _analyticsNavigatorKey =
+    GlobalKey<NavigatorState>(debugLabel: 'analyticsBranch');
+final _accountsNavigatorKey =
+    GlobalKey<NavigatorState>(debugLabel: 'accountsBranch');
+final _settingsNavigatorKey =
+    GlobalKey<NavigatorState>(debugLabel: 'settingsBranch');
+
+final appRouterProvider = Provider<GoRouter>((ref) {
+  return GoRouter(
+    navigatorKey: _rootNavigatorKey,
+    initialLocation: AppRoute.dashboard.path,
+    routes: [
+      StatefulShellRoute.indexedStack(
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (context, state, navigationShell) =>
+            _AppScaffold(navigationShell: navigationShell),
+        branches: [
+          StatefulShellBranch(
+            navigatorKey: _dashboardNavigatorKey,
+            routes: [
+              GoRoute(
+                path: AppRoute.dashboard.path,
+                name: AppRoute.dashboard.name,
+                builder: (context, state) => const DashboardScreen(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            navigatorKey: _groupsNavigatorKey,
+            routes: [
+              GoRoute(
+                path: AppRoute.groups.path,
+                name: AppRoute.groups.name,
+                builder: (context, state) => const GroupsScreen(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            navigatorKey: _analyticsNavigatorKey,
+            routes: [
+              GoRoute(
+                path: AppRoute.analytics.path,
+                name: AppRoute.analytics.name,
+                builder: (context, state) => const AnalyticsScreen(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            navigatorKey: _accountsNavigatorKey,
+            routes: [
+              GoRoute(
+                path: AppRoute.accounts.path,
+                name: AppRoute.accounts.name,
+                builder: (context, state) => const AccountsScreen(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            navigatorKey: _settingsNavigatorKey,
+            routes: [
+              GoRoute(
+                path: AppRoute.settings.path,
+                name: AppRoute.settings.name,
+                builder: (context, state) => const SettingsScreen(),
+              ),
+            ],
+          ),
+        ],
+      ),
+      GoRoute(
+        parentNavigatorKey: _rootNavigatorKey,
+        path: AppRoute.newExpense.path,
+        name: AppRoute.newExpense.name,
+        builder: (context, state) => const NewExpenseScreen(),
+      ),
+      GoRoute(
+        parentNavigatorKey: _rootNavigatorKey,
+        path: AppRoute.settleUp.path,
+        name: AppRoute.settleUp.name,
+        builder: (context, state) => const SettleUpScreen(),
+      ),
+      GoRoute(
+        parentNavigatorKey: _rootNavigatorKey,
+        path: AppRoute.activityDetail.path,
+        name: AppRoute.activityDetail.name,
+        builder: (context, state) => ActivityDetailScreen(
+          activityId: state.pathParameters['activityId'] ?? '',
+        ),
+      ),
+      GoRoute(
+        parentNavigatorKey: _rootNavigatorKey,
+        path: AppRoute.groupDetail.path,
+        name: AppRoute.groupDetail.name,
+        builder: (context, state) => GroupDetailScreen(
+          groupId: state.pathParameters['groupId'] ?? '',
+        ),
+      ),
+      GoRoute(
+        parentNavigatorKey: _rootNavigatorKey,
+        path: AppRoute.addMember.path,
+        name: AppRoute.addMember.name,
+        builder: (context, state) => AddMemberScreen(
+          groupId: state.pathParameters['groupId'] ?? '',
+        ),
+      ),
+      GoRoute(
+        parentNavigatorKey: _rootNavigatorKey,
+        path: AppRoute.groupSettings.path,
+        name: AppRoute.groupSettings.name,
+        builder: (context, state) => GroupSettingsScreen(
+          groupId: state.pathParameters['groupId'] ?? '',
+        ),
+      ),
+    ],
+  );
+});
+
+class _AppScaffold extends StatelessWidget {
+  const _AppScaffold({required this.navigationShell});
+
+  final StatefulNavigationShell navigationShell;
+
+  void _onDestinationSelected(int index) {
+    navigationShell.goBranch(
+      index,
+      initialLocation: index == navigationShell.currentIndex,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorTokens = theme.extension<PaisaColorTokens>();
+    final accentGold = colorTokens?.accentGold ?? theme.colorScheme.tertiary;
+    final inactiveColor =
+        colorTokens?.navigationInactive ?? theme.colorScheme.onSurfaceVariant;
+    final navBackground =
+        colorTokens?.navigationBackground ?? theme.colorScheme.surface;
+
+    return Scaffold(
+      body: navigationShell,
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => context.goNamed(AppRoute.newExpense.name),
+        child: const Icon(Icons.add),
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: navigationShell.currentIndex,
+        onTap: _onDestinationSelected,
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.space_dashboard_outlined),
+            activeIcon: Icon(Icons.space_dashboard),
+            label: 'Dashboard',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.group_outlined),
+            activeIcon: Icon(Icons.group),
+            label: 'Groups',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.pie_chart_outline),
+            activeIcon: Icon(Icons.pie_chart),
+            label: 'Analytics',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.account_balance_wallet_outlined),
+            activeIcon: Icon(Icons.account_balance_wallet),
+            label: 'Accounts',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.settings_outlined),
+            activeIcon: Icon(Icons.settings),
+            label: 'Settings',
+          ),
+        ],
+        selectedItemColor: accentGold,
+        unselectedItemColor: inactiveColor,
+        backgroundColor: navBackground,
+        type: BottomNavigationBarType.fixed,
+      ),
+    );
+  }
+}

--- a/paisasplit/lib/app/theme/colors.dart
+++ b/paisasplit/lib/app/theme/colors.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+
+@immutable
+class PaisaColorTokens extends ThemeExtension<PaisaColorTokens> {
+  const PaisaColorTokens({
+    required this.backgroundRoot,
+    required this.backgroundSurface,
+    required this.borderDivider,
+    required this.textPrimary,
+    required this.textSecondary,
+    required this.textDisabled,
+    required this.brandPrimary,
+    required this.brandOnPrimary,
+    required this.accentGold,
+    required this.accentOnGold,
+    required this.stateSuccess,
+    required this.stateError,
+    required this.stateWarn,
+    required this.stateInfo,
+    required this.navigationInactive,
+    required this.navigationBackground,
+  });
+
+  final Color backgroundRoot;
+  final Color backgroundSurface;
+  final Color borderDivider;
+  final Color textPrimary;
+  final Color textSecondary;
+  final Color textDisabled;
+  final Color brandPrimary;
+  final Color brandOnPrimary;
+  final Color accentGold;
+  final Color accentOnGold;
+  final Color stateSuccess;
+  final Color stateError;
+  final Color stateWarn;
+  final Color stateInfo;
+  final Color navigationInactive;
+  final Color navigationBackground;
+
+  static const PaisaColorTokens dark = PaisaColorTokens(
+    backgroundRoot: Color(0xFF0B1220),
+    backgroundSurface: Color(0xFF0F172A),
+    borderDivider: Color(0xFF1F2A3A),
+    textPrimary: Color(0xFFE6EDF6),
+    textSecondary: Color(0xFFA8B3C7),
+    textDisabled: Color(0xFF6B7280),
+    brandPrimary: Color(0xFF2BB39A),
+    brandOnPrimary: Color(0xFF06231E),
+    accentGold: Color(0xFFC89B3C),
+    accentOnGold: Color(0xFF251A05),
+    stateSuccess: Color(0xFF22C55E),
+    stateError: Color(0xFFEF4444),
+    stateWarn: Color(0xFFF59E0B),
+    stateInfo: Color(0xFF38BDF8),
+    navigationInactive: Color(0xFF94A3B8),
+    navigationBackground: Color(0xFF0F172A),
+  );
+
+  @override
+  PaisaColorTokens copyWith({
+    Color? backgroundRoot,
+    Color? backgroundSurface,
+    Color? borderDivider,
+    Color? textPrimary,
+    Color? textSecondary,
+    Color? textDisabled,
+    Color? brandPrimary,
+    Color? brandOnPrimary,
+    Color? accentGold,
+    Color? accentOnGold,
+    Color? stateSuccess,
+    Color? stateError,
+    Color? stateWarn,
+    Color? stateInfo,
+    Color? navigationInactive,
+    Color? navigationBackground,
+  }) {
+    return PaisaColorTokens(
+      backgroundRoot: backgroundRoot ?? this.backgroundRoot,
+      backgroundSurface: backgroundSurface ?? this.backgroundSurface,
+      borderDivider: borderDivider ?? this.borderDivider,
+      textPrimary: textPrimary ?? this.textPrimary,
+      textSecondary: textSecondary ?? this.textSecondary,
+      textDisabled: textDisabled ?? this.textDisabled,
+      brandPrimary: brandPrimary ?? this.brandPrimary,
+      brandOnPrimary: brandOnPrimary ?? this.brandOnPrimary,
+      accentGold: accentGold ?? this.accentGold,
+      accentOnGold: accentOnGold ?? this.accentOnGold,
+      stateSuccess: stateSuccess ?? this.stateSuccess,
+      stateError: stateError ?? this.stateError,
+      stateWarn: stateWarn ?? this.stateWarn,
+      stateInfo: stateInfo ?? this.stateInfo,
+      navigationInactive: navigationInactive ?? this.navigationInactive,
+      navigationBackground: navigationBackground ?? this.navigationBackground,
+    );
+  }
+
+  @override
+  ThemeExtension<PaisaColorTokens> lerp(
+    covariant ThemeExtension<PaisaColorTokens>? other,
+    double t,
+  ) {
+    if (other is! PaisaColorTokens) {
+      return this;
+    }
+    return PaisaColorTokens(
+      backgroundRoot: Color.lerp(backgroundRoot, other.backgroundRoot, t)!,
+      backgroundSurface:
+          Color.lerp(backgroundSurface, other.backgroundSurface, t)!,
+      borderDivider: Color.lerp(borderDivider, other.borderDivider, t)!,
+      textPrimary: Color.lerp(textPrimary, other.textPrimary, t)!,
+      textSecondary: Color.lerp(textSecondary, other.textSecondary, t)!,
+      textDisabled: Color.lerp(textDisabled, other.textDisabled, t)!,
+      brandPrimary: Color.lerp(brandPrimary, other.brandPrimary, t)!,
+      brandOnPrimary: Color.lerp(brandOnPrimary, other.brandOnPrimary, t)!,
+      accentGold: Color.lerp(accentGold, other.accentGold, t)!,
+      accentOnGold: Color.lerp(accentOnGold, other.accentOnGold, t)!,
+      stateSuccess: Color.lerp(stateSuccess, other.stateSuccess, t)!,
+      stateError: Color.lerp(stateError, other.stateError, t)!,
+      stateWarn: Color.lerp(stateWarn, other.stateWarn, t)!,
+      stateInfo: Color.lerp(stateInfo, other.stateInfo, t)!,
+      navigationInactive:
+          Color.lerp(navigationInactive, other.navigationInactive, t)!,
+      navigationBackground:
+          Color.lerp(navigationBackground, other.navigationBackground, t)!,
+    );
+  }
+}

--- a/paisasplit/lib/app/theme/theme.dart
+++ b/paisasplit/lib/app/theme/theme.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+import 'colors.dart';
+import 'typography.dart';
+
+ThemeData buildPaisaTheme() {
+  const colorScheme = ColorScheme(
+    brightness: Brightness.dark,
+    primary: Color(0xFF2BB39A),
+    onPrimary: Color(0xFF06231E),
+    primaryContainer: Color(0xFF0E3B33),
+    onPrimaryContainer: Color(0xFFBDEFE6),
+    secondary: Color(0xFF334155),
+    onSecondary: Color(0xFFE6EDF6),
+    secondaryContainer: Color(0xFF1F2A3A),
+    onSecondaryContainer: Color(0xFFD7E2F3),
+    tertiary: Color(0xFFC89B3C),
+    onTertiary: Color(0xFF251A05),
+    tertiaryContainer: Color(0xFF3C2D12),
+    onTertiaryContainer: Color(0xFFF2E3BF),
+    error: Color(0xFFEF4444),
+    onError: Color(0xFF1F0A0A),
+    errorContainer: Color(0xFF4C1111),
+    onErrorContainer: Color(0xFFFCDADA),
+    background: Color(0xFF0B1220),
+    onBackground: Color(0xFFE6EDF6),
+    surface: Color(0xFF0F172A),
+    onSurface: Color(0xFFE6EDF6),
+    surfaceVariant: Color(0xFF1F2A3A),
+    onSurfaceVariant: Color(0xFFA8B3C7),
+    outline: Color(0xFF1F2A3A),
+    outlineVariant: Color(0xFF273345),
+    shadow: Color(0x80000000),
+    scrim: Color(0x66000000),
+    inverseSurface: Color(0xFFE6EDF6),
+    inversePrimary: Color(0xFF7CDAC8),
+    surfaceTint: Color(0xFF2BB39A),
+  );
+
+  final colorTokens = PaisaColorTokens.dark;
+  final textTheme = PaisaTypography.textTheme(
+    colorTokens.textPrimary,
+    colorTokens.textSecondary,
+  );
+
+  return ThemeData(
+    useMaterial3: true,
+    brightness: Brightness.dark,
+    colorScheme: colorScheme,
+    scaffoldBackgroundColor: colorTokens.backgroundRoot,
+    canvasColor: colorTokens.backgroundSurface,
+    textTheme: textTheme,
+    appBarTheme: AppBarTheme(
+      backgroundColor: Colors.transparent,
+      elevation: 0,
+      foregroundColor: colorTokens.textPrimary,
+      titleTextStyle: textTheme.titleLarge,
+      centerTitle: false,
+    ),
+    cardTheme: CardTheme(
+      color: colorTokens.backgroundSurface,
+      elevation: 2,
+      margin: EdgeInsets.zero,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+        side: BorderSide(color: colorTokens.borderDivider),
+      ),
+    ),
+    dividerTheme: DividerThemeData(
+      color: colorTokens.borderDivider,
+      thickness: 1,
+      space: 1,
+    ),
+    floatingActionButtonTheme: FloatingActionButtonThemeData(
+      backgroundColor: colorTokens.brandPrimary,
+      foregroundColor: colorTokens.brandOnPrimary,
+      shape: const StadiumBorder(),
+    ),
+    bottomNavigationBarTheme: BottomNavigationBarThemeData(
+      backgroundColor: colorTokens.navigationBackground,
+      selectedItemColor: colorTokens.accentGold,
+      unselectedItemColor: colorTokens.navigationInactive,
+      selectedLabelStyle:
+          textTheme.labelMedium?.copyWith(color: colorTokens.accentGold),
+      unselectedLabelStyle:
+          textTheme.labelMedium?.copyWith(color: colorTokens.navigationInactive),
+      showSelectedLabels: true,
+      showUnselectedLabels: true,
+      type: BottomNavigationBarType.fixed,
+    ),
+    extensions: const <ThemeExtension<dynamic>>[
+      PaisaColorTokens.dark,
+    ],
+  );
+}

--- a/paisasplit/lib/app/theme/typography.dart
+++ b/paisasplit/lib/app/theme/typography.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+class PaisaTypography {
+  const PaisaTypography._();
+
+  static TextTheme textTheme(Color primaryColor, Color secondaryColor) {
+    const fontFamily = 'Roboto';
+
+    final base = const TextTheme(
+      displayLarge: TextStyle(
+        fontSize: 32,
+        fontWeight: FontWeight.w600,
+        height: 1.2,
+        fontFamily: fontFamily,
+      ),
+      headlineLarge: TextStyle(
+        fontSize: 24,
+        fontWeight: FontWeight.w600,
+        height: 1.25,
+        fontFamily: fontFamily,
+      ),
+      headlineMedium: TextStyle(
+        fontSize: 20,
+        fontWeight: FontWeight.w600,
+        height: 1.3,
+        fontFamily: fontFamily,
+      ),
+      titleLarge: TextStyle(
+        fontSize: 18,
+        fontWeight: FontWeight.w600,
+        height: 1.3,
+        fontFamily: fontFamily,
+      ),
+      titleMedium: TextStyle(
+        fontSize: 16,
+        fontWeight: FontWeight.w500,
+        height: 1.4,
+        fontFamily: fontFamily,
+      ),
+      titleSmall: TextStyle(
+        fontSize: 14,
+        fontWeight: FontWeight.w500,
+        height: 1.4,
+        fontFamily: fontFamily,
+      ),
+      bodyLarge: TextStyle(
+        fontSize: 16,
+        fontWeight: FontWeight.w400,
+        height: 1.5,
+        fontFamily: fontFamily,
+      ),
+      bodyMedium: TextStyle(
+        fontSize: 14,
+        fontWeight: FontWeight.w400,
+        height: 1.5,
+        fontFamily: fontFamily,
+      ),
+      bodySmall: TextStyle(
+        fontSize: 12,
+        fontWeight: FontWeight.w400,
+        height: 1.4,
+        fontFamily: fontFamily,
+      ),
+      labelLarge: TextStyle(
+        fontSize: 14,
+        fontWeight: FontWeight.w600,
+        height: 1.4,
+        fontFamily: fontFamily,
+      ),
+      labelMedium: TextStyle(
+        fontSize: 12,
+        fontWeight: FontWeight.w500,
+        height: 1.4,
+        fontFamily: fontFamily,
+      ),
+      labelSmall: TextStyle(
+        fontSize: 11,
+        fontWeight: FontWeight.w500,
+        height: 1.3,
+        fontFamily: fontFamily,
+      ),
+    );
+
+    return base.copyWith(
+      bodyMedium: base.bodyMedium?.copyWith(color: secondaryColor),
+      bodySmall: base.bodySmall?.copyWith(color: secondaryColor),
+      titleSmall: base.titleSmall?.copyWith(color: secondaryColor),
+    ).apply(
+      bodyColor: primaryColor,
+      displayColor: primaryColor,
+      decorationColor: primaryColor,
+    );
+  }
+}

--- a/paisasplit/lib/features/accounts/accounts_screen.dart
+++ b/paisasplit/lib/features/accounts/accounts_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class AccountsScreen extends StatelessWidget {
+  const AccountsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Accounts'),
+      ),
+      body: Center(
+        child: Text(
+          'Accounts Placeholder',
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      ),
+    );
+  }
+}

--- a/paisasplit/lib/features/analytics/analytics_screen.dart
+++ b/paisasplit/lib/features/analytics/analytics_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class AnalyticsScreen extends StatelessWidget {
+  const AnalyticsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Analytics'),
+      ),
+      body: Center(
+        child: Text(
+          'Analytics Placeholder',
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      ),
+    );
+  }
+}

--- a/paisasplit/lib/features/dashboard/activity_detail_screen.dart
+++ b/paisasplit/lib/features/dashboard/activity_detail_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class ActivityDetailScreen extends StatelessWidget {
+  const ActivityDetailScreen({super.key, required this.activityId});
+
+  final String activityId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Activity Detail'),
+      ),
+      body: Center(
+        child: Text(
+          'Activity ID: $activityId',
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      ),
+    );
+  }
+}

--- a/paisasplit/lib/features/dashboard/dashboard_screen.dart
+++ b/paisasplit/lib/features/dashboard/dashboard_screen.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class DashboardScreen extends StatelessWidget {
+  const DashboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Dashboard'),
+        actions: const [
+          Padding(
+            padding: EdgeInsets.only(right: 16),
+            child: CircleAvatar(child: Icon(Icons.person_outline)),
+          ),
+        ],
+      ),
+      body: Center(
+        child: Text(
+          'Dashboard Content Placeholder',
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      ),
+    );
+  }
+}

--- a/paisasplit/lib/features/expenses/new_expense_screen.dart
+++ b/paisasplit/lib/features/expenses/new_expense_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class NewExpenseScreen extends StatelessWidget {
+  const NewExpenseScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('New Expense'),
+      ),
+      body: Center(
+        child: Text(
+          'New Expense Placeholder',
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      ),
+    );
+  }
+}

--- a/paisasplit/lib/features/groups/add_member_screen.dart
+++ b/paisasplit/lib/features/groups/add_member_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class AddMemberScreen extends StatelessWidget {
+  const AddMemberScreen({super.key, required this.groupId});
+
+  final String groupId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Add Member'),
+      ),
+      body: Center(
+        child: Text(
+          'Add Member Placeholder for $groupId',
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      ),
+    );
+  }
+}

--- a/paisasplit/lib/features/groups/group_detail_screen.dart
+++ b/paisasplit/lib/features/groups/group_detail_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class GroupDetailScreen extends StatelessWidget {
+  const GroupDetailScreen({super.key, required this.groupId});
+
+  final String groupId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Group $groupId'),
+      ),
+      body: Center(
+        child: Text(
+          'Group Detail Placeholder for $groupId',
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      ),
+    );
+  }
+}

--- a/paisasplit/lib/features/groups/group_settings_screen.dart
+++ b/paisasplit/lib/features/groups/group_settings_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class GroupSettingsScreen extends StatelessWidget {
+  const GroupSettingsScreen({super.key, required this.groupId});
+
+  final String groupId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Group Settings'),
+      ),
+      body: Center(
+        child: Text(
+          'Group Settings Placeholder for $groupId',
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      ),
+    );
+  }
+}

--- a/paisasplit/lib/features/groups/groups_screen.dart
+++ b/paisasplit/lib/features/groups/groups_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class GroupsScreen extends StatelessWidget {
+  const GroupsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Groups'),
+      ),
+      body: Center(
+        child: Text(
+          'Groups Placeholder',
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      ),
+    );
+  }
+}

--- a/paisasplit/lib/features/settings/settings_screen.dart
+++ b/paisasplit/lib/features/settings/settings_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Settings'),
+      ),
+      body: Center(
+        child: Text(
+          'Settings Placeholder',
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      ),
+    );
+  }
+}

--- a/paisasplit/lib/features/settle/settle_up_screen.dart
+++ b/paisasplit/lib/features/settle/settle_up_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class SettleUpScreen extends StatelessWidget {
+  const SettleUpScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Settle Up'),
+      ),
+      body: Center(
+        child: Text(
+          'Settle Up Placeholder',
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add design tokens and typography for the dark theme per UI spec and wire them into the app theme
- configure go_router with the bottom navigation shell, named routes, and FAB navigation to New Expense
- stub out feature screens with scaffolds so navigation targets are ready for future implementation

## Testing
- not run (Flutter SDK unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e17214d0608333a0ea86631b0f42eb