### PR TITLE
ci: add Flutter build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,74 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      - name: Run build_runner
+        run: dart run build_runner build -d
+
+      - name: Analyze
+        run: dart analyze
+
+      - name: Test
+        run: flutter test
+
+      - name: Build debug APK
+        run: flutter build apk --debug
+
+      - name: Build release APKs (per ABI)
+        run: flutter build apk --release --split-per-abi
+
+      - name: Prepare APK artifacts
+        run: |
+          ARTIFACT_DIR="build/ci-artifacts"
+          mkdir -p "${ARTIFACT_DIR}"
+          cp build/app/outputs/flutter-apk/app-debug.apk "${ARTIFACT_DIR}/PaisaSplit-debug-universal.apk"
+          cp build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk "${ARTIFACT_DIR}/PaisaSplit-release-armeabi-v7a.apk"
+          cp build/app/outputs/flutter-apk/app-arm64-v8a-release.apk "${ARTIFACT_DIR}/PaisaSplit-release-arm64-v8a.apk"
+          cp build/app/outputs/flutter-apk/app-x86_64-release.apk "${ARTIFACT_DIR}/PaisaSplit-release-x86_64.apk"
+
+      - name: Upload APK artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: PaisaSplit-APK-${{ github.sha }}
+          path: build/ci-artifacts/
+
+      # Optional: Enable this section when signing release builds for tagged versions.
+      # - name: Build signed release APKs
+      #   if: startsWith(github.ref, 'refs/tags/')
+      #   env:
+      #     ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+      #     ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      #     ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+      #     ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+      #   run: |
+      #     echo "${ANDROID_KEYSTORE_BASE64}" | base64 --decode > android/app/release.keystore
+      #     flutter build apk --release --split-per-abi --obfuscate --split-debug-info=build/debug-info
+      #     rm -f android/app/release.keystore


### PR DESCRIPTION
## Summary
- add CI workflow to setup Flutter stable, run build_runner, analyze, test, and build APKs
- upload debug universal and per-ABI release APK artifacts with SHA-based naming
- document optional signed release section for tagged builds

## Testing
- not run (workflow definition only)


------
https://chatgpt.com/codex/tasks/task_e_68e178da5794833383770257c651e110