### PR TITLE
feat: INR currency + date utils

### DIFF
--- a/paisasplit/analysis_options.yaml
+++ b/paisasplit/analysis_options.yaml
@@ -1,6 +1,8 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
+  exclude:
+    - lib/gen/**
   errors:
     todo: error
     unused_import: error

--- a/paisasplit/lib/core/formatters/currency_formatter.dart
+++ b/paisasplit/lib/core/formatters/currency_formatter.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../app/theme/colors.dart';
+
+final NumberFormat _currencyFormatter = NumberFormat.currency(
+  locale: 'en_IN',
+  symbol: '₹',
+  decimalDigits: 2,
+);
+
+num _toRupees(int amountInPaise) => amountInPaise / 100;
+
+/// Formats an [amountInPaise] to an INR currency string using lakh/crore grouping.
+String formatCurrencyFromPaise(int amountInPaise) {
+  final rupees = _toRupees(amountInPaise);
+  return _currencyFormatter.format(rupees);
+}
+
+/// Formats an [amountInPaise] into a compact INR string (e.g. `₹1.2L`).
+String formatCompactCurrency(int amountInPaise) {
+  final rupees = _toRupees(amountInPaise).toDouble();
+  final sign = rupees < 0 ? '-' : '';
+  final absValue = rupees.abs();
+
+  String suffix;
+  double divisor;
+
+  if (absValue >= 10000000) {
+    suffix = 'Cr';
+    divisor = 10000000;
+  } else if (absValue >= 100000) {
+    suffix = 'L';
+    divisor = 100000;
+  } else if (absValue >= 1000) {
+    suffix = 'K';
+    divisor = 1000;
+  } else {
+    return formatCurrencyFromPaise(amountInPaise);
+  }
+
+  final scaled = absValue / divisor;
+  final decimals = scaled >= 100 ? 0 : 1;
+  var number = scaled.toStringAsFixed(decimals);
+  if (number.endsWith('.0')) {
+    number = number.substring(0, number.length - 2);
+  }
+
+  return '$sign₹$number$suffix';
+}
+
+/// Returns a color hint for negative amounts using the theme tokens.
+Color? negativeAmountHintColor(BuildContext context, int amountInPaise) {
+  if (amountInPaise >= 0) {
+    return null;
+  }
+
+  final theme = Theme.of(context);
+  final tokens = theme.extension<PaisaColorTokens>();
+  return tokens?.stateError ?? theme.colorScheme.error;
+}
+
+/// Convenience flag to check if an [amountInPaise] represents a debit value.
+bool isNegativeAmount(int amountInPaise) => amountInPaise < 0;

--- a/paisasplit/lib/core/formatters/date_utils.dart
+++ b/paisasplit/lib/core/formatters/date_utils.dart
@@ -1,0 +1,45 @@
+const List<String> _monthAbbreviations = <String>[
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+/// Formats [date] using the PaisaSplit display pattern `DD MMM YYYY`.
+String formatDisplayDate(DateTime date) {
+  final normalized = DateTime(date.year, date.month, date.day);
+  final day = normalized.day.toString().padLeft(2, '0');
+  final month = _monthAbbreviations[normalized.month - 1];
+  final year = normalized.year.toString();
+  return '$day $month $year';
+}
+
+/// Returns the Monday of the week for the provided [date].
+DateTime startOfWeek(DateTime date) {
+  final normalized = DateTime(date.year, date.month, date.day);
+  final difference = (normalized.weekday - DateTime.monday) % DateTime.daysPerWeek;
+  return normalized.subtract(Duration(days: difference));
+}
+
+/// Returns the Sunday of the week for the provided [date].
+DateTime endOfWeek(DateTime date) {
+  final start = startOfWeek(date);
+  return start.add(const Duration(days: DateTime.daysPerWeek - 1));
+}
+
+/// Returns all calendar days for the week containing [date], starting Monday.
+List<DateTime> daysOfWeek(DateTime date) {
+  final start = startOfWeek(date);
+  return List<DateTime>.generate(
+    DateTime.daysPerWeek,
+    (index) => start.add(Duration(days: index)),
+  );
+}

--- a/paisasplit/lib/core/result/result.dart
+++ b/paisasplit/lib/core/result/result.dart
@@ -1,0 +1,51 @@
+sealed class Result<T, E> {
+  const Result();
+
+  bool get isSuccess => this is Success<T, E>;
+  bool get isFailure => this is Failure<T, E>;
+
+  R fold<R>({
+    required R Function(T value) onSuccess,
+    required R Function(E error) onFailure,
+  }) {
+    final self = this;
+    if (self is Success<T, E>) {
+      return onSuccess(self.value);
+    }
+    final failure = self as Failure<T, E>;
+    return onFailure(failure.error);
+  }
+
+  Result<U, E> map<U>(U Function(T value) transform) {
+    final self = this;
+    if (self is Success<T, E>) {
+      return Success<U, E>(transform(self.value));
+    }
+    final failure = self as Failure<T, E>;
+    return Failure<U, E>(failure.error);
+  }
+
+  Result<T, F> mapError<F>(F Function(E error) transform) {
+    final self = this;
+    if (self is Success<T, E>) {
+      return Success<T, F>(self.value);
+    }
+    final failure = self as Failure<T, E>;
+    return Failure<T, F>(transform(failure.error));
+  }
+
+  static Result<T, E> success<T, E>(T value) => Success<T, E>(value);
+  static Result<T, E> failure<T, E>(E error) => Failure<T, E>(error);
+}
+
+final class Success<T, E> extends Result<T, E> {
+  const Success(this.value);
+
+  final T value;
+}
+
+final class Failure<T, E> extends Result<T, E> {
+  const Failure(this.error);
+
+  final E error;
+}

--- a/paisasplit/lib/main.dart
+++ b/paisasplit/lib/main.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
 
 import 'app/app.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  Intl.defaultLocale = 'en_IN';
+  await initializeDateFormatting('en_IN', null);
   runApp(const ProviderScope(child: PaisaSplitApp()));
 }

--- a/paisasplit/test/core/formatters_test.dart
+++ b/paisasplit/test/core/formatters_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+import 'package:intl/date_symbol_data_local.dart';
+
+import 'package:paisasplit/app/theme/colors.dart';
+import 'package:paisasplit/app/theme/theme.dart';
+import 'package:paisasplit/core/formatters/currency_formatter.dart';
+import 'package:paisasplit/core/formatters/date_utils.dart';
+
+void main() {
+  setUpAll(() async {
+    Intl.defaultLocale = 'en_IN';
+    await initializeDateFormatting('en_IN', null);
+  });
+
+  test('formats INR currency with lakh/crore grouping', () {
+    const amountInPaise = 12345600; // ₹1,23,456.00
+    final formatted = formatCurrencyFromPaise(amountInPaise);
+
+    expect(formatted, '₹1,23,456.00');
+  });
+
+  test('formats compact INR currency using lakh shorthand', () {
+    const amountInPaise = 12345600; // ₹1.2L
+    final formatted = formatCompactCurrency(amountInPaise);
+
+    expect(formatted, '₹1.2L');
+  });
+
+  test('formats dates using DD MMM YYYY pattern', () {
+    final date = DateTime(2025, 9, 7);
+
+    expect(formatDisplayDate(date), '07 Sep 2025');
+  });
+
+  test('computes Monday as the start of week and Sunday as end', () {
+    final date = DateTime(2025, 9, 7); // Sunday
+
+    expect(startOfWeek(date), DateTime(2025, 9, 1));
+    expect(endOfWeek(date), DateTime(2025, 9, 7));
+    expect(daysOfWeek(date).first, DateTime(2025, 9, 1));
+    expect(daysOfWeek(date).last, DateTime(2025, 9, 7));
+  });
+
+  testWidgets('negative amount hint uses error token', (tester) async {
+    const amount = -100;
+
+    late Color? hintColor;
+
+    await tester.pumpWidget(MaterialApp(
+      theme: buildPaisaTheme(),
+      home: Builder(
+        builder: (context) {
+          hintColor = negativeAmountHintColor(context, amount);
+          return const SizedBox.shrink();
+        },
+      ),
+    ));
+
+    final theme = buildPaisaTheme();
+    final tokens = theme.extension<PaisaColorTokens>();
+    expect(hintColor, tokens?.stateError ?? theme.colorScheme.error);
+  });
+}


### PR DESCRIPTION
## Summary
- add INR currency formatter with compact numerals and negative hint helper
- create date utilities for DD MMM YYYY output and Monday-based week calculations plus Result type helper
- initialize en_IN locale at startup and cover formatting logic with unit tests

## Testing
- flutter pub get
- dart run build_runner build -d
- dart analyze --fatal-infos --fatal-warnings
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68e17f1f37288333a86abb8adc924cc0